### PR TITLE
Target API 31 for S+ Problem Fixed

### DIFF
--- a/PhysicaloidLibrary/src/com/physicaloid/lib/usb/UsbAccessor.java
+++ b/PhysicaloidLibrary/src/com/physicaloid/lib/usb/UsbAccessor.java
@@ -59,7 +59,7 @@ public enum UsbAccessor {
         }
 
         if(mPermissionIntent == null) {
-            mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("USB_PERMISSION"), 0);
+            mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("USB_PERMISSION"), PendingIntent.FLAG_IMMUTABLE);
         }
     }
 

--- a/PhysicaloidLibrary/src/com/physicaloid/lib/usb/UsbAccessor.java
+++ b/PhysicaloidLibrary/src/com/physicaloid/lib/usb/UsbAccessor.java
@@ -59,7 +59,11 @@ public enum UsbAccessor {
         }
 
         if(mPermissionIntent == null) {
-            mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("USB_PERMISSION"), PendingIntent.FLAG_IMMUTABLE);
+            if(android.os.Build.VERSION.SDK_INT >= 31) {
+                mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("USB_PERMISSION"), PendingIntent.FLAG_IMMUTABLE);
+            } else {
+                mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent("USB_PERMISSION"), 0);
+            }
         }
     }
 


### PR DESCRIPTION
05-19 21:14:54.447 11333 11819 E ReactNativePhysicaloid: java.lang.IllegalArgumentException: com.???.???: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.

05-19 21:14:54.447 11333 11819 E ReactNativePhysicaloid: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.

Tested this problem with Arduino Uno at Galaxy Tab. It worked.